### PR TITLE
Add websocket support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ const blockbook = new Blockbook({
   nodes: ['btc1.trezor.io', 'btc2.trezor.io'],
 })
 
-// Example methods
+// Example methods using http
 await blockbook.getStatus()
 await blockbook.getBlockHash(100000) // -> '000000000003ba27aa200b1cecaad478d2b00432346c3f1f3986da1afd33e506'
 await blockbook.getTx('b62aa5203fa27495ea431b91a5090aab741c8c39cc03ec4c1f4f4e157507595f')
@@ -28,6 +28,14 @@ await blockbook.getUtxosForAddress('193P6LtvS4nCnkDvM9uXn1gsSRqh4aDAz7')
 await blockbook.getUtxosForXpub('xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8', { confirmed: true })
 await blockbook.getBlock(100000)
 await blockbook.sendTx('<hex tx data>')
+
+// To use websockets
+await blockbook.connect()
+await blockbook.subscribeNewBlock(({ height, hash }) => console.log('new block', height, hash))
+await blockbook.subscribeAddresses(['193P6LtvS4nCnkDvM9uXn1gsSRqh4aDAz7'], ({ address, tx }) => console.log('new tx for address', address, tx))
+await blockbook.unsubscribeNewBlock()
+await blockbook.unsubscribeAddresses()
+await blockbook.disconnect()
 
 // For more specific typings of bitcoin-like or ethereum-like coins use one of
 // the following classes instead. The `Blockbook` class will work with any coin

--- a/package-lock.json
+++ b/package-lock.json
@@ -656,6 +656,15 @@
       "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
       "dev": true
     },
+    "@types/ws": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.1.tgz",
+      "integrity": "sha512-ISCK1iFnR+jYv7+jLNX0wDqesZ/5RAeY3wUx6QaphmocphU61h+b+PHjS18TF4WIPTu/MMzxIq2PHr32o2TS5Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/yargs": {
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.3.tgz",
@@ -3920,6 +3929,17 @@
         "whatwg-url": "^6.4.1",
         "ws": "^5.2.0",
         "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+          "dev": true,
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
       }
     },
     "jsesc": {
@@ -6464,6 +6484,14 @@
         "shelljs": "^0.8.3",
         "typedoc-default-themes": "^0.6.1",
         "typescript": "3.7.x"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "3.7.7",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.7.tgz",
+          "integrity": "sha512-MmQdgo/XenfZPvVLtKZOq9jQQvzaUAUpcKW8Z43x9B2fOm4S5g//tPtMweZUIP+SoBqrVPEIm+dJeQ9dfO0QdA==",
+          "dev": true
+        }
       }
     },
     "typedoc-default-themes": {
@@ -6479,9 +6507,9 @@
       }
     },
     "typescript": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
-      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
+      "version": "3.9.9",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.9.tgz",
+      "integrity": "sha512-kdMjTiekY+z/ubJCATUPlRDl39vXYiMV9iyeMuEuXZh2we6zz80uovNN2WlAxmmdE/Z/YQe+EbOEXB5RHEED3w==",
       "dev": true
     },
     "uglify-js": {
@@ -6769,13 +6797,9 @@
       }
     },
     "ws": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
-      "dev": true,
-      "requires": {
-        "async-limiter": "~1.0.0"
-      }
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+      "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw=="
     },
     "xml-name-validator": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/node": "^10.17.3",
     "@types/qs": "^6.9.0",
     "@types/request-promise-native": "^1.0.17",
+    "@types/ws": "^7.4.1",
     "coveralls": "^3.0.2",
     "jest": "^24.9.0",
     "jest-circus": "^24.9.0",
@@ -73,13 +74,14 @@
     "ts-node": "^8.4.1",
     "tslint": "^5.20.0",
     "typedoc": "^0.15.0",
-    "typescript": "^3.7.2"
+    "typescript": "^3.9.9"
   },
   "dependencies": {
     "@faast/ts-common": "^0.6.0",
     "io-ts": "^1.10.4",
     "qs": "^6.9.1",
     "request": "^2.88.0",
-    "request-promise-native": "^1.0.8"
+    "request-promise-native": "^1.0.8",
+    "ws": "^7.4.4"
   }
 }

--- a/src/BaseBlockbook.ts
+++ b/src/BaseBlockbook.ts
@@ -50,7 +50,6 @@ export abstract class BaseBlockbook<
   private subscriptions: { [id: string]: { callback: Resolve, method: string } } = {}
   private subscribeNewBlockId = ''
   private subscribeAddressesId = ''
-  private subscribeAddressesCurrent: string[] = []
 
   constructor(
     config: BlockbookConfig,
@@ -139,7 +138,6 @@ export abstract class BaseBlockbook<
     this.subscriptions = {}
     this.subscribeNewBlockId = ''
     this.subscribeAddressesId = ''
-    this.subscribeAddressesCurrent = []
     let node = this.getNode()
     if (node.startsWith('http')) {
       node = node.replace('http', 'ws')

--- a/src/BaseBlockbook.ts
+++ b/src/BaseBlockbook.ts
@@ -1,13 +1,17 @@
+import { BlockHashResponseWs } from './types/common';
 import request from 'request-promise-native'
-import { assertType } from '@faast/ts-common'
+import { assertType, DelegateLogger, isMatchingError, isString, Logger } from '@faast/ts-common'
 import * as t from 'io-ts'
+import WebSocket from 'ws'
+
 import {
   XpubDetailsBasic, XpubDetailsTokens, XpubDetailsTokenBalances, XpubDetailsTxids, XpubDetailsTxs,
   BlockbookConfig, SystemInfo, BlockHashResponse, GetAddressDetailsOptions,
   UtxoDetails, UtxoDetailsXpub, GetUtxosOptions, GetXpubDetailsOptions,
   SendTxSuccess, SendTxError,
+  Resolve, Reject, SystemInfoWs
 } from './types'
-import { jsonRequest } from './utils'
+import { jsonRequest, USER_AGENT } from './utils'
 
 const xpubDetailsCodecs = {
   basic: XpubDetailsBasic,
@@ -17,6 +21,12 @@ const xpubDetailsCodecs = {
   txs: XpubDetailsTxs,
 }
 
+/**
+ * Blockbook client with support for both http and ws with multi-node and type validation support.
+ *
+ * Reference websocket implementation based on:
+ * https://github.com/trezor/blockbook/blob/master/static/test-websocket.html
+ */
 export abstract class BaseBlockbook<
   NormalizedTx,
   SpecificTx,
@@ -29,7 +39,18 @@ export abstract class BaseBlockbook<
 > {
   nodes: string[]
   disableTypeValidation: boolean
+  requestTimeoutMs: number
+  ws: WebSocket
+  wsConnected: boolean
+  logger: Logger
+
   private requestCounter = 0
+  private pingIntervalId: NodeJS.Timeout
+  private pendingWsRequests: { [id: string]: { resolve: Resolve, reject: Reject } } = {}
+  private subscriptions: { [id: string]: { callback: Resolve, method: string } } = {}
+  private subscribeNewBlockId = ''
+  private subscribeNewTransactionId = ''
+  private subscribeAddressesId = ''
 
   constructor(
     config: BlockbookConfig,
@@ -45,11 +66,20 @@ export abstract class BaseBlockbook<
     }
   ) {
     config = assertType(BlockbookConfig, config)
-    this.nodes = config.nodes
-    if (this.nodes.length === 0) {
+    if (config.nodes.length === 0) {
       throw new Error('Blockbook node list must not be empty')
     }
+    // trim trailing slash
+    this.nodes = config.nodes.map((node) => node.trim().replace(/\/$/, ''))
+
+    // validate all responses by default
     this.disableTypeValidation = config.disableTypeValidation || false
+
+    // fail fast by default
+    this.requestTimeoutMs = config.requestTimeoutMs || 5000
+
+    // prefix all log messages with package name
+    this.logger = new DelegateLogger(config.logger, 'blockbook-client')
   }
 
   doAssertType<T>(codec: t.Type<T, any, unknown>, value: unknown, ...rest: any[]): T {
@@ -59,32 +89,194 @@ export abstract class BaseBlockbook<
     return assertType(codec, value, ...rest)
   }
 
-  async doRequest(
+
+  /** Load balance using round robin. Helps any retry logic fallback to different nodes */
+  private getNode() {
+    return this.nodes[this.requestCounter++ % this.nodes.length]
+  }
+
+  async httpRequest(
     method: 'GET' | 'POST', path: string, params?: object, body?: object, options?: Partial<request.Options>,
   ) {
-    // Load balance using round robin. Helps any retry logic fallback to different nodes
-    let node = this.nodes[this.requestCounter++ % this.nodes.length]
-    return jsonRequest(node, method, path, params, body, options)
+    return jsonRequest(this.getNode(), method, path, params, body, { timeout: this.requestTimeoutMs, ...options })
+  }
+
+  wsRequest(method: string, params?: object, idOption?: string): Promise<any> {
+    const id = idOption ?? (this.requestCounter++).toString()
+    const req = {
+        id,
+        method,
+        params
+    }
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        delete this.pendingWsRequests[id]
+        reject(`Timeout waiting for websocket ${method} response (id: ${id})`)
+      }, this.requestTimeoutMs)
+      this.pendingWsRequests[id] = { resolve, reject }
+      this.ws.send(JSON.stringify(req))
+    })
+  }
+
+  subscribe(method: string, params: object, callback: (result: any) => void) {
+    const id = (this.requestCounter++).toString()
+    this.subscriptions[id] = { callback, method }
+    return [id, this.wsRequest(method, params)]
+  }
+
+  unsubscribe(method: string, params: object, id: string) {
+    delete this.subscriptions[id]
+    return this.wsRequest(method, params)
+  }
+
+  async connect(): Promise<void> {
+    if (this.wsConnected) {
+      return
+    }
+    this.pendingWsRequests = {}
+    this.subscriptions = {}
+    this.subscribeNewBlockId = ''
+    this.subscribeNewTransactionId = ''
+    this.subscribeAddressesId = ''
+    let node = this.getNode()
+    if (node.startsWith('http')) {
+      node = node.replace('http', 'ws')
+    }
+    if (!node.startsWith('ws')) {
+      node = `wss://${node}`
+    }
+    if (!node.endsWith('/websocket')) {
+      node += '/websocket'
+    }
+
+    // Wait for the connection before resolving
+    await new Promise<void>((resolve, reject) => {
+      this.ws = new WebSocket(node, { headers: { 'user-agent': USER_AGENT } })
+      this.ws.once('open', (e) => {
+        this.logger.log('socket connected', e)
+        this.wsConnected = true
+        resolve()
+      })
+      this.ws.once('error', (e) => {
+        this.logger.warn('socket connect error', e)
+        this.ws.close()
+        reject(e)
+      })
+    })
+
+    this.ws.on('close', (e) => {
+      this.logger.warn('socket closed', e)
+      this.wsConnected = false
+      clearInterval(this.pingIntervalId)
+    })
+    this.ws.on('error', (e) => {
+      this.logger.warn('socket error ', e)
+      this.wsConnected = false
+      this.ws.close()
+    })
+
+    // Parse all incoming messages and forward them to any pending requests or subscriptions
+    this.ws.on('message', (data) => {
+      this.logger.debug('socket message', data)
+      if (!isString(data)) {
+        this.logger.error(`Unrecognized websocket data type ${typeof data} received from ${node}`)
+        return
+      }
+      let response
+      try {
+        response = JSON.parse(data)
+      } catch (e) {
+        this.logger.error(`Failed to parse websocket data received from ${node}`, e.toString())
+        return
+      }
+      const id = response.id
+      if (!isString(id)) {
+        this.logger.error(`Received websocket data without a valid ID from ${node}`, response)
+      }
+      const result = response.data
+      let errorMessage: string = ''
+      if (result?.error) {
+        errorMessage = result.error.message ?? data
+      }
+      const pendingRequest = this.pendingWsRequests[id]
+      if (pendingRequest) {
+          delete this.pendingWsRequests[id]
+          if (errorMessage) {
+            return pendingRequest.reject(new Error(errorMessage))
+          }
+          return pendingRequest.resolve(result)
+      }
+      const activeSubscription = this.subscriptions[id]
+      if (activeSubscription) {
+        if (errorMessage) {
+          this.logger.error(
+            `Received error response for ${activeSubscription.method} subscription from ${node}`,
+            errorMessage,
+          )
+        }
+        return activeSubscription.callback(result)
+      }
+      this.logger.warn(`Unrecognized websocket data (id: ${id}) received from ${node}`, result)
+    })
+
+    // Periodically ping the server and disconnect when unresponsive
+    this.pingIntervalId = setInterval(async () => {
+      try {
+        await this.wsRequest('ping', {})
+      } catch (e) {
+        this.ws.terminate() // force close
+      }
+    }, 25000)
+  }
+
+  /* Close the websocket or do nothing if not connected */
+  async disconnect(): Promise<void> {
+    if (!this.wsConnected) {
+      return
+    }
+    return new Promise((resolve, reject) => {
+      this.ws.once('close', () => resolve())
+      this.ws.once('error', (e) => reject(e))
+      this.ws.close()
+    })
+  }
+
+  // ws getInfo
+  async getInfo(): Promise<SystemInfoWs> {
+    if (!this.wsConnected) {
+      throw new Error('Websocket must be connected to call getInfo')
+    }
+    const response = await this.wsRequest('getInfo')
+    return this.doAssertType(SystemInfoWs, response)
   }
 
   async getStatus(): Promise<SystemInfo> {
-    const response = await this.doRequest('GET', '/api/v2')
+    const response = await this.httpRequest('GET', '/api/v2')
     return this.doAssertType(SystemInfo, response)
   }
 
   async getBlockHash(blockNumber: number): Promise<string> {
-    const response = await this.doRequest('GET', `/api/v2/block-index/${blockNumber}`)
+    if (this.wsConnected) {
+      const response = await this.wsRequest('getBlockHash', { height: blockNumber })
+      const { hash } = this.doAssertType(BlockHashResponseWs, response)
+      return hash
+    }
+    const response = await this.httpRequest('GET', `/api/v2/block-index/${blockNumber}`)
     const { blockHash } = this.doAssertType(BlockHashResponse, response)
     return blockHash
   }
 
   async getTx(txid: string): Promise<NormalizedTx> {
-    const response = await this.doRequest('GET', `/api/v2/tx/${txid}`)
+    const response = this.wsConnected
+      ? await this.wsRequest('getTransaction', { txid })
+      : await this.httpRequest('GET', `/api/v2/tx/${txid}`)
     return this.doAssertType(this.normalizedTxCodec, response)
   }
 
   async getTxSpecific(txid: string): Promise<SpecificTx> {
-    const response = await this.doRequest('GET', `/api/v2/tx-specific/${txid}`)
+    const response = this.wsConnected
+      ? await this.wsRequest('getTransactionSpecific', { txid })
+      : await this.httpRequest('GET', `/api/v2/tx-specific/${txid}`)
     return this.doAssertType(this.specificTxCodec, response)
   }
 
@@ -109,8 +301,10 @@ export abstract class BaseBlockbook<
     options: GetAddressDetailsOptions & { details: 'txs' },
   ): Promise<AddressDetailsTxs>
   async getAddressDetails(address: string, options: GetAddressDetailsOptions = {}) {
-    const response = await this.doRequest('GET', `/api/v2/address/${address}`, options)
     const detailsLevel = options.details || 'txids'
+    const response = this.wsConnected
+      ? await this.wsRequest('getAccountInfo', { descriptor: address, ...options, details: detailsLevel })
+      : await this.httpRequest('GET', `/api/v2/address/${address}`, { ...options, details: detailsLevel })
     const codec: t.Mixed = this.addressDetailsCodecs[detailsLevel]
     return this.doAssertType(codec, response)
   }
@@ -136,34 +330,42 @@ export abstract class BaseBlockbook<
     options: GetXpubDetailsOptions & { details: 'txs' },
   ): Promise<XpubDetailsTxs>
   async getXpubDetails(xpub: string, options: GetXpubDetailsOptions = {}) {
-    const response = await this.doRequest('GET', `/api/v2/xpub/${xpub}`, options)
+    const tokens = options.tokens || 'derived'
     const detailsLevel = options.details || 'txids'
+    const response = this.wsConnected
+      ? await this.wsRequest('getAccountInfo', { descriptor: xpub, details: detailsLevel, tokens, ...options })
+      : await this.httpRequest('GET', `/api/v2/xpub/${xpub}`, { details: detailsLevel, tokens, ...options })
     const codec: t.Mixed = xpubDetailsCodecs[detailsLevel]
     return this.doAssertType(codec, response)
   }
 
   async getUtxosForAddress(address: string, options: GetUtxosOptions = {}): Promise<UtxoDetails[]> {
-    const response = await this.doRequest('GET', `/api/v2/utxo/${address}`, options)
+    const response = this.wsConnected
+      ? await this.wsRequest('getAccountUtxo', { descriptor: address, ...options })
+      : await this.httpRequest('GET', `/api/v2/utxo/${address}`, options)
     return this.doAssertType(t.array(UtxoDetails), response)
   }
 
   async getUtxosForXpub(xpub: string, options: GetUtxosOptions = {}): Promise<UtxoDetailsXpub[]> {
-    const response = await this.doRequest('GET', `/api/v2/utxo/${xpub}`, options)
+    const response = this.wsConnected
+      ? await this.wsRequest('getAccountUtxo', { descriptor: xpub, ...options })
+      : await this.httpRequest('GET', `/api/v2/utxo/${xpub}`, options)
     return this.doAssertType(t.array(UtxoDetailsXpub), response)
   }
 
   async getBlock(block: string | number): Promise<BlockInfo> {
-    const response = await this.doRequest('GET', `/api/v2/block/${block}`)
+    // http only
+    const response = await this.httpRequest('GET', `/api/v2/block/${block}`)
     return this.doAssertType(this.blockInfoCodec, response)
   }
 
   async sendTx(txHex: string): Promise<string> {
     // NOTE: sendtx POST doesn't work without trailing slash, and sendtx GET fails for large txs
-    const response = await this.doRequest('POST', '/api/v2/sendtx/', undefined, undefined, { body: txHex, json: false })
-    if (SendTxError.is(response)) {
-      throw new Error(`blockbook sendtx returned error: ${response.error.message}`)
-    } else {
-      return (response as SendTxSuccess).result
-    }
+    const response = this.wsConnected
+      ? await this.wsRequest('sendTransaction', { hex: txHex })
+      : await this.httpRequest('POST', '/api/v2/sendtx/', undefined, undefined, { body: txHex, json: false })
+
+    const { result: txHash } = this.doAssertType(SendTxSuccess, response)
+    return txHash
   }
 }

--- a/src/types/bitcoin.ts
+++ b/src/types/bitcoin.ts
@@ -160,16 +160,16 @@ export const TokenDetailsXpubAddress = t.type({
   path: t.string, // 'm/44'/3'/0'/0/0',
   transfers: t.number, // 3,
   decimals: t.number, // 8,
-  balance: t.string, // '0',
-  totalReceived: t.string, // '2803986975',
-  totalSent: t.string, // '2803986975'
 }, 'TokenDetailsXpubAddress')
 export type TokenDetailsXpubAddress = t.TypeOf<typeof TokenDetailsXpubAddress>
 
 export const TokenDetailsXpubAddressBalance = extendCodec(
   TokenDetailsXpubAddress,
+  {},
   {
-    balance: t.string, // '850360'
+    balance: t.string, // '0',
+    totalReceived: t.string, // '2803986975',
+    totalSent: t.string, // '2803986975'
   },
   'TokenDetailsXpubAddressBalance',
 )
@@ -182,7 +182,7 @@ export const XpubDetailsTokens = extendCodec(
   XpubDetailsBasic,
   {},
   {
-    tokens: TokenDetailsXpubAddress,
+    tokens: t.array(TokenDetailsXpubAddress),
   },
   'XpubDetailsTokens'
 )
@@ -192,7 +192,7 @@ export const XpubDetailsTokenBalances = extendCodec(
   XpubDetailsBasic,
   {},
   {
-    tokens: TokenDetailsXpubAddressBalance,
+    tokens: t.array(TokenDetailsXpubAddressBalance)
   },
   'XpubDetailsTokenBalances'
 )

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -103,20 +103,6 @@ export const SystemInfoWs = t.type(
 export type SystemInfoWs = t.TypeOf<typeof SystemInfoWs>
 
 /*
- * Get block hash
- */
-
- export const BlockHashResponse = t.type({
-  blockHash: t.string, // 'ed8f3af8c10ca70a136901c6dd3adf037f0aea8a93fbe9e80939214034300f1e'
-}, 'BlockHashResponse')
-export type BlockHashResponse = t.TypeOf<typeof BlockHashResponse>
-
-export const BlockHashResponseWs = t.type({
- hash: t.string, // 'ed8f3af8c10ca70a136901c6dd3adf037f0aea8a93fbe9e80939214034300f1e'
-}, 'BlockHashResponseWs')
-export type BlockHashResponseWs = t.TypeOf<typeof BlockHashResponseWs>
-
-/*
  * Get transaction
  */
 
@@ -276,6 +262,40 @@ export const NormalizedTxCommon = requiredOptionalCodec(
   'NormalizedTxCommon',
 )
 export type NormalizedTxCommon = t.TypeOf<typeof NormalizedTxCommon>
+
+/*
+ * Get block hash
+ */
+
+export const BlockHashResponse = t.type({
+  blockHash: t.string, // 'ed8f3af8c10ca70a136901c6dd3adf037f0aea8a93fbe9e80939214034300f1e'
+}, 'BlockHashResponse')
+export type BlockHashResponse = t.TypeOf<typeof BlockHashResponse>
+
+export const BlockHashResponseWs = t.type({
+ hash: t.string, // 'ed8f3af8c10ca70a136901c6dd3adf037f0aea8a93fbe9e80939214034300f1e'
+}, 'BlockHashResponseWs')
+export type BlockHashResponseWs = t.TypeOf<typeof BlockHashResponseWs>
+
+/**
+ * subscribeNewBlock
+ */
+
+export const SubscribeNewBlockEvent = t.type({
+  height: t.number,
+  hash: t.string,
+}, 'SubscribeNewBlockEvent')
+export type SubscribeNewBlockEvent = t.TypeOf<typeof SubscribeNewBlockEvent>
+
+/**
+ * subscribeAddresses
+ */
+
+export const SubscribeAddressesEvent = t.type({
+  address: t.string,
+  tx: NormalizedTxCommon,
+}, 'SubscribeAddressesEvent')
+export type SubscribeAddressesEvent = t.TypeOf<typeof SubscribeAddressesEvent>
 
 /**
  * Get address

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,5 +1,8 @@
 import * as t from 'io-ts'
-import { requiredOptionalCodec, extendCodec } from '@faast/ts-common'
+import { requiredOptionalCodec, extendCodec, Logger, nullable } from '@faast/ts-common'
+
+export type Resolve = (value: any) => void
+export type Reject = (reason?: any) => void
 
 export const Paginated = t.type({
   page: t.number, // 1,
@@ -22,8 +25,10 @@ export const BlockbookConfig = requiredOptionalCodec(
      * Default: `false`
      */
     disableTypeValidation: t.boolean,
-    /** Set to milliseconds to change debounce interval */
-    debounce: t.number,
+    /** Maximum ms to wait for an http or ws request to complete */
+    requestTimeoutMs: t.number,
+    /** Logger to use. undefined -> console, null -> disabled */
+    logger: nullable(Logger),
   },
   'BlockbookConfig',
 )
@@ -79,6 +84,24 @@ export const SystemInfo = t.type({
 }, 'ApiStatus')
 export type SystemInfo = t.TypeOf<typeof SystemInfo>
 
+/**
+ * ws getInfo
+ */
+export const SystemInfoWs = t.type(
+  {
+    name: t.string,
+    shortcut: t.string,
+    decimals: t.number,
+    version: t.string,
+    bestHeight: t.number,
+    bestHash: t.string,
+    block0Hash: t.string,
+    testnet: t.boolean,
+  },
+  'SystemInfoWs',
+)
+export type SystemInfoWs = t.TypeOf<typeof SystemInfoWs>
+
 /*
  * Get block hash
  */
@@ -87,6 +110,11 @@ export type SystemInfo = t.TypeOf<typeof SystemInfo>
   blockHash: t.string, // 'ed8f3af8c10ca70a136901c6dd3adf037f0aea8a93fbe9e80939214034300f1e'
 }, 'BlockHashResponse')
 export type BlockHashResponse = t.TypeOf<typeof BlockHashResponse>
+
+export const BlockHashResponseWs = t.type({
+ hash: t.string, // 'ed8f3af8c10ca70a136901c6dd3adf037f0aea8a93fbe9e80939214034300f1e'
+}, 'BlockHashResponseWs')
+export type BlockHashResponseWs = t.TypeOf<typeof BlockHashResponseWs>
 
 /*
  * Get transaction

--- a/test/BlockbookBitcoin.test.ts
+++ b/test/BlockbookBitcoin.test.ts
@@ -90,6 +90,8 @@ describe('BlockbookBitcoin', () => {
     let bb = new BlockbookBitcoin({
       nodes: NODES,
     })
+    const blockEvents = []
+    const addressEvents = []
 
     beforeAll(async () => {
       await bb.connect()
@@ -116,10 +118,28 @@ describe('BlockbookBitcoin', () => {
       })
     })
 
-    runStandardTests(bb)
-
-    describe('subscribeBlock', () => {
-
+    describe('subscribeNewBlock', () => {
+      it('can subscribe', async () => {
+        const result = await bb.subscribeNewBlock(console.log)
+        expect(result).toEqual({ subscribed: true })
+      })
+      it('can unsubscribe', async () => {
+        const result = await bb.unsubscribeNewBlock()
+        expect(result).toEqual({ subscribed: false })
+      })
     })
+
+    describe('subscribeAddresses', () => {
+      it('can subscribe to address', async () => {
+        const result = await bb.subscribeAddresses([ADDRESS], console.log)
+        expect(result).toEqual({ subscribed: true })
+      })
+      it('can unsubscribe', async () => {
+        const result = await bb.unsubscribeAddresses()
+        expect(result).toEqual({ subscribed: false })
+      })
+    })
+
+    runStandardTests(bb)
   })
 })

--- a/test/BlockbookBitcoin.test.ts
+++ b/test/BlockbookBitcoin.test.ts
@@ -1,5 +1,6 @@
 import { BlockbookBitcoin } from '../src'
 
+const NODES = ['btc1.trezor.io', 'btc2.trezor.io', 'btc3.trezor.io']
 const BLOCK_NUMBER = 100000
 const BLOCK_HASH = '000000000003ba27aa200b1cecaad478d2b00432346c3f1f3986da1afd33e506'
 const XPUB = 'xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8'
@@ -8,72 +9,117 @@ const TXID = '251b9c567fc7bca1cd354ce7aa278d48af79438ccae871a585b4b89d10aaa649'
 const RAW_TX = '0200000001d1442246db3345a611d864e7753ee1e4dd7476817aacf53c4fbfa17447c5e8ab000000006b483045022100910d62240028c179011c2cd15ded7353422db26c17f95225683c412a8d89e1ee0220017c427c8e4252d7d28fac5b95068ff8604d15755c7ff3b36459824041446ec8012102430848768b5fba28c043fd71ba01acf38e7ae356fc27f1312bd8b283c1d22358fdffffff020c200100000000001976a91420745eb623e0103fdc499a7369b91c96655df09588ac88e703000000000017a914751ef966546056ee26ffeeee3cf9dc33b42da8bb875f420900'
 
 describe('BlockbookBitcoin', () => {
-  const bb = new BlockbookBitcoin({
-    nodes: ['btc1.trezor.io', 'btc2.trezor.io', 'btc3.trezor.io'],
-  })
-  describe('getStatus', () => {
-    it('succeeds', async () => {
-      expect(await bb.getStatus()).toBeDefined()
-    })
-    it('throws for bad node then succeeds for good', async () => {
-      const bb2 = new BlockbookBitcoin({
-        nodes: ['btc1234.trezor.io', 'btc1.trezor.io'],
+  function runStandardTests(bb: BlockbookBitcoin) {
+    describe('getBlockHash', () => {
+      it('returns correct hash', async () => {
+        expect(await bb.getBlockHash(BLOCK_NUMBER)).toBe(BLOCK_HASH)
       })
-      await expect(bb2.getXpubDetails(XPUB)).rejects.toThrow('ENOTFOUND')
-      expect(await bb2.getXpubDetails(XPUB)).toBeDefined()
     })
+    describe('getTx', () => {
+      it('succeeds', async () => {
+        expect(await bb.getTx(TXID)).toBeDefined()
+      })
+      it('throws on invalid txid', async () => {
+        await expect(bb.getTx('1234')).rejects.toThrow("Transaction '1234' not found")
+      })
+    })
+    describe('getTxSpecific', () => {
+      it('succeeds', async () => {
+        expect(await bb.getTxSpecific(TXID)).toBeDefined()
+      })
+    })
+    describe('getAddressDetails', () => {
+      it('succeeds with only address', async () => {
+        expect(await bb.getAddressDetails(ADDRESS)).toBeDefined()
+      })
+      it('succeeds with custom details level', async () => {
+        expect(await bb.getAddressDetails(ADDRESS, { details: 'basic' })).toBeDefined()
+      })
+    })
+    describe('getXpubDetails', () => {
+      it('succeeds', async () => {
+        expect(await bb.getXpubDetails(XPUB)).toBeDefined()
+      })
+    })
+    describe('getUtxosForAddress', () => {
+      it('succeeds', async () => {
+        expect(await bb.getUtxosForAddress(ADDRESS)).toBeDefined()
+      })
+    })
+    describe('getUtxosForXpub', () => {
+      it('succeeds', async () => {
+        expect(await bb.getUtxosForXpub(XPUB)).toBeDefined()
+      })
+    })
+    describe('getBlock', () => {
+      it('succeeds', async () => {
+        const block = await bb.getBlock(BLOCK_NUMBER)
+        expect(block).toBeDefined()
+        expect(block.hash).toBe(BLOCK_HASH)
+      })
+    })
+    describe('sendTx throws on already broadcast', () => {
+      it('succeeds', async () => {
+        await expect(bb.sendTx(RAW_TX)).rejects.toThrow()
+      })
+    })
+  }
+
+  describe('http', () => {
+    const bb = new BlockbookBitcoin({
+      nodes: NODES,
+    })
+
+    describe('getStatus', () => {
+      it('succeeds', async () => {
+        expect(await bb.getStatus()).toBeDefined()
+      })
+      it('throws for bad node then succeeds for good', async () => {
+        const bb2 = new BlockbookBitcoin({
+          nodes: ['btc1234.trezor.io', 'btc1.trezor.io'],
+        })
+        await expect(bb2.getStatus()).rejects.toThrow('ENOTFOUND')
+        expect(await bb2.getStatus()).toBeDefined()
+      })
+    })
+
+    runStandardTests(bb)
   })
-  describe('getBlockHash', () => {
-    it('returns correct hash', async () => {
-      expect(await bb.getBlockHash(BLOCK_NUMBER)).toBe(BLOCK_HASH)
+
+  describe.only('ws', () => {
+    let bb = new BlockbookBitcoin({
+      nodes: NODES,
     })
-  })
-  describe('getTx', () => {
-    it('succeeds', async () => {
-      expect(await bb.getTx(TXID)).toBeDefined()
+
+    beforeAll(async () => {
+      await bb.connect()
     })
-    it('throws on invalid txid', async () => {
-      await expect(bb.getTx('1234')).rejects.toThrow("Transaction '1234' not found")
+
+    afterAll(async () => {
+      await bb.disconnect()
     })
-  })
-  describe('getTxSpecific', () => {
-    it('succeeds', async () => {
-      expect(await bb.getTxSpecific(TXID)).toBeDefined()
+
+    describe('getInfo', () => {
+      it('succeeds', async () => {
+        expect(await bb.getInfo()).toBeDefined()
+      })
+      it('throws for bad node then succeeds for good', async () => {
+        const bb2 = new BlockbookBitcoin({
+          nodes: ['btc1234.trezor.io', 'btc1.trezor.io'],
+        })
+        await expect(bb2.connect()).rejects.toThrow('ENOTFOUND')
+        try {
+          await bb2.connect()
+        } finally {
+          await bb2.disconnect()
+        }
+      })
     })
-  })
-  describe('getAddressDetails', () => {
-    it('succeeds with only address', async () => {
-      expect(await bb.getAddressDetails(ADDRESS)).toBeDefined()
-    })
-    it('succeeds with custom details level', async () => {
-      expect(await bb.getAddressDetails(ADDRESS, { details: 'basic' })).toBeDefined()
-    })
-  })
-  describe('getXpubDetails', () => {
-    it('succeeds', async () => {
-      expect(await bb.getXpubDetails(XPUB)).toBeDefined()
-    })
-  })
-  describe('getUtxosForAddress', () => {
-    it('succeeds', async () => {
-      expect(await bb.getUtxosForAddress(ADDRESS)).toBeDefined()
-    })
-  })
-  describe('getUtxosForXpub', () => {
-    it('succeeds', async () => {
-      expect(await bb.getUtxosForXpub(XPUB)).toBeDefined()
-    })
-  })
-  describe('getBlock', () => {
-    it('succeeds', async () => {
-      const block = await bb.getBlock(BLOCK_NUMBER)
-      expect(block).toBeDefined()
-      expect(block.hash).toBe(BLOCK_HASH)
-    })
-  })
-  describe('sendTx throws on already broadcast', () => {
-    it('succeeds', async () => {
-      await expect(bb.sendTx(RAW_TX)).rejects.toThrow()
+
+    runStandardTests(bb)
+
+    describe('subscribeBlock', () => {
+
     })
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "./node_modules/@faast/ts-config/library/tsconfig.json",
   "compilerOptions": {
+    "module": "es6",
+    "target": "es2019",
     "baseUrl": ".",
     "outDir": "dist/lib",
     "paths": {


### PR DESCRIPTION
Supports websocket for all existing methods other than `getBlock` which doesn't appear to have a websocket equivalent.

Support was added for the following subscriptions:
- subscribeAddresses
- subscribeNewBlock

Also resolves the following issues:
- https://github.com/go-faast/blockbook-client/issues/2
- https://github.com/go-faast/blockbook-client/issues/9